### PR TITLE
Set coupling intervals for MPAS compsets

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -251,6 +251,14 @@
       <value compset=".+" grid="a%mpasa15"                    >360</value>
       <value compset=".+" grid="a%mpasa7p5"                   >720</value>
       <value compset=".+" grid="a%mpasa3p75"                  >1440</value>
+      <value compset="_MPAS" grid="a%mpasa480"                >2</value>
+      <value compset="_MPAS" grid="a%mpasa240"                >2</value>
+      <value compset="_MPAS" grid="a%mpasa120"                >2</value>
+      <value compset="_MPAS" grid="a%mpasa60"                 >4</value>
+      <value compset="_MPAS" grid="a%mpasa30"                 >8</value>
+      <value compset="_MPAS" grid="a%mpasa15"                 >15</value>
+      <value compset="_MPAS" grid="a%mpasa7p5"                >30</value>
+      <value compset="_MPAS" grid="a%mpasa3p75"               >60</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -355,6 +363,7 @@
       <value compset="_XATM.*_XLND.*_XICE.*_XOCN" >$ATM_NCPL</value>
       <value compset="_DLND.*_CISM\d"             >1</value>
       <value compset="_XROF"                      >$ATM_NCPL</value>
+      <value compset="_MPAS"                      >$ATM_NCPL</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -240,6 +240,17 @@
       <!-- =================================================== -->
       <value compset="_DATM.*_BLOM">24</value>
       <value compset="_BLOM" grid="oi%tnx0.25v">48</value>
+      <!-- =================================================== -->
+      <!-- EarthWorks specific -->
+      <!-- =================================================== -->
+      <value compset=".+" grid="a%mpasa480"                   >48</value>
+      <value compset=".+" grid="a%mpasa240"                   >48</value>
+      <value compset=".+" grid="a%mpasa120"                   >48</value>
+      <value compset=".+" grid="a%mpasa60"                    >96</value>
+      <value compset=".+" grid="a%mpasa30"                    >192</value>
+      <value compset=".+" grid="a%mpasa15"                    >360</value>
+      <value compset=".+" grid="a%mpasa7p5"                   >720</value>
+      <value compset=".+" grid="a%mpasa3p75"                  >1440</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -364,6 +364,7 @@
       <value compset="_DLND.*_CISM\d"             >1</value>
       <value compset="_XROF"                      >$ATM_NCPL</value>
       <value compset="_MPAS"                      >$ATM_NCPL</value>
+      <value compset="_MOSART_" grid="a%mpasa.+"  >$ATM_NCPL</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Set coupling intervals for various compsets by adding settings for `ATM_NCPL` based on the MPAS-A grids.

Also sets `ROC_NCPL` to follow `ATM_NCPL` if the compset name contains the substring "_MPAS"

Important context: https://github.com/EarthWorksOrg/EarthWorks/pull/45#issuecomment-2118165239