### PR TITLE
Make PIO_NETCDF_FORMAT default to 64bit_data

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -2051,15 +2051,15 @@
     https://www.unidata.ucar.edu/software/netcdf/docs/data_type.html
     </desc>
     <values>
-      <value compclass="ATM">64bit_offset</value>
-      <value compclass="CPL">64bit_offset</value>
-      <value compclass="OCN">64bit_offset</value>
-      <value compclass="WAV">64bit_offset</value>
-      <value compclass="GLC">64bit_offset</value>
-      <value compclass="ICE">64bit_offset</value>
-      <value compclass="ROF">64bit_offset</value>
-      <value compclass="LND">64bit_offset</value>
-      <value compclass="ESP">64bit_offset</value>
+      <value compclass="ATM">64bit_data</value>
+      <value compclass="CPL">64bit_data</value>
+      <value compclass="OCN">64bit_data</value>
+      <value compclass="WAV">64bit_data</value>
+      <value compclass="GLC">64bit_data</value>
+      <value compclass="ICE">64bit_data</value>
+      <value compclass="ROF">64bit_data</value>
+      <value compclass="LND">64bit_data</value>
+      <value compclass="ESP">64bit_data</value>
     </values>
   </entry>
 


### PR DESCRIPTION
The previous default, `64bit_offset` is best used for compatibility. However, high-resolution compsets (e.g. mpasa015_oQU015) will fail to write restart files due to the amount of data being written. Using `64bit_data` should still be compatible with most systems since it is available in any NetCDF version newer than v4.4. May increase overall file size.