### PR TITLE
Update mpas-ocean version

### DIFF
--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -1391,6 +1391,16 @@ contains
        end if
     end if
     if (phase == 'advertise') then
+       call addfld_from(compice, 'Si_ithick')
+       call addfld_to(compatm, 'Si_ithick')
+    else
+       if ( fldchk(is_local%wrap%FBexp(compatm)        , 'Si_ithick', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compice,compice), 'Si_ithick', rc=rc)) then
+          call addmap_from(compice, 'Si_ithick', compatm, mapconsf, 'ifrac', ice2atm_map)
+          call addmrg_to(compatm, 'Si_ithick', mrg_from=compice, mrg_fld='Si_ithick', mrg_type='copy')
+       end if
+    end if
+    if (phase == 'advertise') then
        call addfld_from(compice, 'Si_vsno')
        call addfld_to(compatm, 'Si_vsno')
     else
@@ -2288,6 +2298,229 @@ contains
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_lamult', rc=rc)) then
           call addmap_from(compwav, 'Sw_lamult', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
           call addmrg_to(compocn, 'Sw_lamult', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_Hs')
+       call addfld_to(compocn, 'Sw_Hs')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_Hs', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_Hs', rc=rc)) then
+          call addmap_from(compwav, 'Sw_Hs', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_Hs', mrg_from=compwav, mrg_fld='Sw_hs', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_Fp')
+       call addfld_to(compocn, 'Sw_Fp')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_Fp', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_Fp', rc=rc)) then
+          call addmap_from(compwav, 'Sw_Fp', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_Fp', mrg_from=compwav, mrg_fld='Sw_Fp', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_ustokes_wavenumber_1')
+       call addfld_to(compocn, 'Sw_ustokes_wavenumber_1')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_1', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_1', rc=rc)) then
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_1', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_1', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_1', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_vstokes_wavenumber_1')
+       call addfld_to(compocn, 'Sw_vstokes_wavenumber_1')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_1', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_1', rc=rc)) then
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_1', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_1', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_ustokes_wavenumber_2')
+       call addfld_to(compocn, 'Sw_ustokes_wavenumber_2')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_2', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_2', rc=rc)) then
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_2', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_2', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_2', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_vstokes_wavenumber_2')
+       call addfld_to(compocn, 'Sw_vstokes_wavenumber_2')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_2', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_2', rc=rc)) then
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_2', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_2', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_ustokes_wavenumber_3')
+       call addfld_to(compocn, 'Sw_ustokes_wavenumber_3')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_3', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_3', rc=rc)) then
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_3', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_3', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_3', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_vstokes_wavenumber_3')
+       call addfld_to(compocn, 'Sw_vstokes_wavenumber_3')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_3', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_3', rc=rc)) then
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_3', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_3', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_ustokes_wavenumber_4')
+       call addfld_to(compocn, 'Sw_ustokes_wavenumber_4')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_4', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_4', rc=rc)) then
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_4', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_4', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_4', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_vstokes_wavenumber_4')
+       call addfld_to(compocn, 'Sw_vstokes_wavenumber_4')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_4', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_4', rc=rc)) then
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_4', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_4', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_ustokes_wavenumber_5')
+       call addfld_to(compocn, 'Sw_ustokes_wavenumber_5')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_5', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_5', rc=rc)) then
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_5', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_5', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_5', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_vstokes_wavenumber_5')
+       call addfld_to(compocn, 'Sw_vstokes_wavenumber_5')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_5', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_5', rc=rc)) then
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_5', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_5', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_ustokes_wavenumber_6')
+       call addfld_to(compocn, 'Sw_ustokes_wavenumber_6')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_6', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_6', rc=rc)) then
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_6', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_vstokes_wavenumber_6')
+       call addfld_to(compocn, 'Sw_vstokes_wavenumber_6')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_6', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_6', rc=rc)) then
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_ustokes_wavenumber_6')
+       call addfld_to(compocn, 'Sw_ustokes_wavenumber_6')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_6', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_6', rc=rc)) then
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_6', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: 
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_vstokes_wavenumber_6')
+       call addfld_to(compocn, 'Sw_vstokes_wavenumber_6')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_6', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_6', rc=rc)) then
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+       end if
+    end if
+
+
+    !-----------------------------
+    ! to ocn:
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_Dp')
+       call addfld_to(compocn, 'Sw_Dp')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_Dp', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_Dp', rc=rc)) then
+          call addmap_from(compwav, 'Sw_Dp', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg_to(compocn, 'Sw_Dp', mrg_from=compwav, mrg_fld='Sw_Dp', mrg_type='copy')
        end if
     end if
     !-----------------------------

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -2507,7 +2507,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_Hs', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_Hs', rc=rc)) then
-          call addmap_from(compwav, 'Sw_Hs', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_Hs', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_Hs', mrg_from=compwav, mrg_fld='Sw_hs', mrg_type='copy')
        end if
     end if
@@ -2520,7 +2520,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_Fp', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_Fp', rc=rc)) then
-          call addmap_from(compwav, 'Sw_Fp', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_Fp', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_Fp', mrg_from=compwav, mrg_fld='Sw_Fp', mrg_type='copy')
        end if
     end if
@@ -2533,7 +2533,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_1', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_1', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_1', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_1', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_ustokes_wavenumber_1', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_1', mrg_type='copy')
        end if
     end if
@@ -2546,7 +2546,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_1', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_1', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_1', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_1', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_vstokes_wavenumber_1', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
        end if
     end if
@@ -2559,7 +2559,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_2', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_2', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_2', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_2', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_ustokes_wavenumber_2', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_2', mrg_type='copy')
        end if
     end if
@@ -2572,7 +2572,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_2', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_2', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_2', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_2', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_vstokes_wavenumber_2', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
        end if
     end if
@@ -2585,7 +2585,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_3', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_3', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_3', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_3', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_ustokes_wavenumber_3', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_3', mrg_type='copy')
        end if
     end if
@@ -2598,7 +2598,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_3', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_3', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_3', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_3', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_vstokes_wavenumber_3', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
        end if
     end if
@@ -2611,7 +2611,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_4', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_4', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_4', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_4', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_ustokes_wavenumber_4', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_4', mrg_type='copy')
        end if
     end if
@@ -2624,7 +2624,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_4', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_4', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_4', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_4', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_vstokes_wavenumber_4', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
        end if
     end if
@@ -2637,7 +2637,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_5', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_5', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_5', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_5', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_ustokes_wavenumber_5', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_5', mrg_type='copy')
        end if
     end if
@@ -2650,7 +2650,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_5', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_5', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_5', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_5', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_vstokes_wavenumber_5', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
        end if
     end if
@@ -2663,7 +2663,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_6', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_6', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_ustokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_6', mrg_type='copy')
        end if
     end if
@@ -2676,7 +2676,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_6', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_6', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_vstokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
        end if
     end if
@@ -2689,7 +2689,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_6', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_6', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_ustokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_ustokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_6', mrg_type='copy')
        end if
     end if
@@ -2702,7 +2702,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_6', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_6', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_vstokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_vstokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
        end if
     end if
@@ -2717,7 +2717,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_Dp', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_Dp', rc=rc)) then
-          call addmap_from(compwav, 'Sw_Dp', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmap_from(compwav, 'Sw_Dp', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
           call addmrg_to(compocn, 'Sw_Dp', mrg_from=compwav, mrg_fld='Sw_Dp', mrg_type='copy')
        end if
     end if

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -739,6 +739,10 @@
        canonical_units: m
        description: sea-ice export - surface_snow_water_equivalent
      #
+     - standard_name: Si_ithick
+       canonical_units: m
+       description: sea-ice export - ice thickness
+     #
      - standard_name: Si_vsno
        alias: mean_snow_volume
        canonical_units: m
@@ -1163,6 +1167,66 @@
      - standard_name: Sw_lamult
        canonical_units: 1
        description: ocean import - Langmuir multiplier
+     #
+     - standard_name: Sw_Hs
+       canonical_units: m
+       description: ocean import - Significant wave height
+     #
+     - standard_name: Sw_Fp
+       canonical_units: 1
+       description: ocean import - Peak wave frequency
+     #
+     - standard_name: Sw_Dp
+       canonical_units: 1
+       description: ocean import - Peak wave direction
+     #
+     - standard_name: Sw_ustokes_wavenumber_1
+       canonical_units: m/s
+       description: ocean import - partitioned Stokes drift zonal wavenumber 1
+     #
+     - standard_name: Sw_vstokes_wavenumber_1
+       canonical_units: m/s
+       description: ocean import - partitioned Stokes drift meridional wavenumber 1
+     #
+     - standard_name: Sw_ustokes_wavenumber_2
+       canonical_units: m/s
+       description: ocean import - partitioned Stokes drift zonal wavenumber 2
+     #
+     - standard_name: Sw_vstokes_wavenumber_2
+       canonical_units: m/s
+       description: ocean import - partitioned Stokes drift meridional wavenumber 2
+     #
+     - standard_name: Sw_ustokes_wavenumber_3
+       canonical_units: m/s
+       description: ocean import - partitioned Stokes drift zonal wavenumber 3
+     #
+     - standard_name: Sw_vstokes_wavenumber_3
+       canonical_units: m/s
+       description: ocean import - partitioned Stokes drift meridional wavenumber 3
+     #
+     - standard_name: Sw_ustokes_wavenumber_4
+       canonical_units: m/s
+       description: ocean import - partitioned Stokes drift zonal wavenumber 4
+     #
+     - standard_name: Sw_vstokes_wavenumber_4
+       canonical_units: m/s
+       description: ocean import - partitioned Stokes drift meridional wavenumber 4
+     #
+     - standard_name: Sw_ustokes_wavenumber_5
+       canonical_units: m/s
+       description: ocean import - partitioned Stokes drift zonal wavenumber 5
+     #
+     - standard_name: Sw_vstokes_wavenumber_5
+       canonical_units: m/s
+       description: ocean import - partitioned Stokes drift meridional wavenumber 5
+     #
+     - standard_name: Sw_ustokes_wavenumber_6
+       canonical_units: m/s
+       description: ocean import - partitioned Stokes drift zonal wavenumber 6
+     #
+     - standard_name: Sw_vstokes_wavenumber_6
+       canonical_units: m/s
+       description: ocean import - partitioned Stokes drift meridional wavenumber 6
      #
      - standard_name: Sw_ustokes
        canonical_units: m/s


### PR DESCRIPTION
The mpas-ocean component is updated to a new version: branch 'vanroekel/ocean/update-nonhydro-2-15-2023' of https://github.com/vanroekel/E3SM . This new version permits GPU acceleration to be implemented to the ocean, and features a non-hydrostatic treatment of the vertical coordinate in the split-implicit time integration scheme.

The changes in CMEPS involve adding entries for new wave to ocean coupling variables.

This is part of a package of PRs for branches named update/ocean:
EarthWorksOrg /mpas-ocean PR #14
EarthWorksOrg /mpas-seaice PR #16
EarthWorksOrg /mpas-framework PR #10
EarthWorksOrg /CMEPS PR #12
EarthWorksOrg/EarthWorks PR #47

To clone this version of Earthworks use the update/ocean branch.
