### PR TITLE
Update to tag 'cmeps1.1.2'

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -15,5 +15,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           create_annotated_tag: true
           default_bump: minor
-          dry_run: true
+          dry_run: false
           tag_prefix: cmeps

--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -14,6 +14,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           create_annotated_tag: true
-          default_bump: patch
-          dry_run: false
+          default_bump: minor
+          dry_run: true
           tag_prefix: cmeps

--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v5.5
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           create_annotated_tag: true
-          default_bump: minor
+          default_bump: patch
           dry_run: false
           tag_prefix: cmeps

--- a/cesm/nuopc_cap_share/shr_megan_mod.F90
+++ b/cesm/nuopc_cap_share/shr_megan_mod.F90
@@ -43,13 +43,13 @@ module shr_megan_mod
      integer               :: index
      real(r8), pointer     :: emis_factors(:) ! function of plant-function-type (PFT)
      integer               :: class_number    ! MEGAN class number
-     real(r8)              :: coeff           ! emissions component coeffecient
      real(r8)              :: molec_weight    ! molecular weight of the MEGAN compound (g/mole)
      type(shr_megan_megcomp_t), pointer :: next_megcomp ! points to next member in the linked list
   endtype shr_megan_megcomp_t
 
   type shr_megan_comp_ptr
-    type(shr_megan_megcomp_t), pointer :: ptr
+     type(shr_megan_megcomp_t), pointer :: ptr
+     real(r8) :: coeff           ! emissions component coeffecient
   endtype shr_megan_comp_ptr
 
   ! chemical compound in CAM mechanism that has MEGAN emissions
@@ -227,7 +227,8 @@ contains
        if (localPet==0) write(logunit,*) ' species : ', item%name
        do j = 1,item%n_terms
           if (localPet==0) write(logunit,'(f12.4,a,a)')  item%coeffs(j),' * ', item%vars(j)
-          shr_megan_mechcomps(i)%megan_comps(j)%ptr => add_megan_comp( item%vars(j), item%coeffs(j) )
+          shr_megan_mechcomps(i)%megan_comps(j)%ptr => add_megan_comp( item%vars(j) )
+          shr_megan_mechcomps(i)%megan_comps(j)%coeff = item%coeffs(j)
        enddo
        shr_megan_mechcomps_n = shr_megan_mechcomps_n+1
 
@@ -243,10 +244,9 @@ contains
 
   !-------------------------------------------------------------------------
 
-  function add_megan_comp( name, coeff ) result(megan_comp)
+  function add_megan_comp( name ) result(megan_comp)
 
     character(len=16), intent(in) :: name
-    real(r8),          intent(in) :: coeff
     type(shr_megan_megcomp_t), pointer :: megan_comp
 
     megan_comp => get_megan_comp_by_name(shr_megan_linkedlist, name)
@@ -264,7 +264,7 @@ contains
     megan_comp%index = shr_megan_megcomps_n+1
 
     megan_comp%name = trim(name)
-    megan_comp%coeff = coeff
+
     nullify(megan_comp%next_megcomp)
 
     call add_megan_comp_to_list(megan_comp)

--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -1,7 +1,7 @@
 <components version="2.0">
   <comp_archive_spec compname="drv" compclass="cpl">
     <rest_file_extension>r</rest_file_extension>
-    <hist_file_extension>hi?\d*.*\.nc$</hist_file_extension>
+    <hist_file_extension>h[ix]?\d*\..*\.nc(\.gz)?$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.cpl$NINST_STRING</rpointer_file>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -62,6 +62,27 @@
   <!-- definitions case directories -->
   <!-- ===================================================================== -->
 
+   <entry id="DRV_RESTART_POINTER">
+     <type>char</type>
+     <default_value>rpointer.cpl</default_value>
+     <group>run_begin_stop_restart</group>
+     <file>env_run.xml</file>
+     <desc>
+       Name of the restart pointer file, this can be used to restart from an
+       intermediate restart by appending the restart date and time in format YYYY-MM-DD-SSSSS
+     </desc>
+   </entry>
+ 
+   <entry id="RUN_POSTPROCESSING">
+     <type>logical</type>
+     <valid_values>TRUE,FALSE</valid_values>
+     <default_value>FALSE</default_value>
+     <group>run_data_archive</group>
+     <file>env_run.xml</file>
+     <desc>Logical to run post-processing analysis tools.
+     If TRUE, post-processing scripts will be run</desc>
+   </entry>
+
   <entry id="CASEROOT">
     <type>char</type>
     <default_value>UNSET</default_value>
@@ -1744,6 +1765,22 @@
     <file>env_mach_pes.xml</file>
     <desc>ROOTPE (mpi task in MPI_COMM_WORLD) for each component</desc>
   </entry>
+   <entry id="MEM_PER_TASK">
+     <type>integer</type>
+     <default_value>0</default_value>
+     <group>mach_pes_last</group>
+     <file>env_mach_pes.xml</file>
+     <desc>minimum memory request per node (currently only used on derecho)</desc>
+   </entry>
+ 
+   <entry id="MAX_MEM_PER_NODE">
+     <type>integer</type>
+     <default_value>0</default_value>
+    <group>mach_pes_last</group>
+     <file>env_mach_pes.xml</file>
+     <desc>maximum memory request per node (currently only used on derecho)</desc>
+   </entry>
+ 
   <entry id="MULTI_DRIVER">
     <type>logical</type>
     <default_value>TRUE</default_value>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -859,7 +859,18 @@
     on linking to the PETSc library. Currently this is used by
     CLM. This is currently only supported for certain machines.</desc>
   </entry>
-
+ 
+ <entry id="USE_FTORCH">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc> TRUE implies linking to the FTorch library to allow calls between
+    fortran and a PyTorch model that has been saved to TorchScript.
+    </desc>
+  </entry>
+  
   <entry id="USE_ALBANY">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -62,27 +62,6 @@
   <!-- definitions case directories -->
   <!-- ===================================================================== -->
 
-   <entry id="DRV_RESTART_POINTER">
-     <type>char</type>
-     <default_value>rpointer.cpl</default_value>
-     <group>run_begin_stop_restart</group>
-     <file>env_run.xml</file>
-     <desc>
-       Name of the restart pointer file, this can be used to restart from an
-       intermediate restart by appending the restart date and time in format YYYY-MM-DD-SSSSS
-     </desc>
-   </entry>
- 
-   <entry id="RUN_POSTPROCESSING">
-     <type>logical</type>
-     <valid_values>TRUE,FALSE</valid_values>
-     <default_value>FALSE</default_value>
-     <group>run_data_archive</group>
-     <file>env_run.xml</file>
-     <desc>Logical to run post-processing analysis tools.
-     If TRUE, post-processing scripts will be run</desc>
-   </entry>
-
   <entry id="CASEROOT">
     <type>char</type>
     <default_value>UNSET</default_value>
@@ -1786,22 +1765,7 @@
     <file>env_mach_pes.xml</file>
     <desc>ROOTPE (mpi task in MPI_COMM_WORLD) for each component</desc>
   </entry>
-   <entry id="MEM_PER_TASK">
-     <type>integer</type>
-     <default_value>0</default_value>
-     <group>mach_pes_last</group>
-     <file>env_mach_pes.xml</file>
-     <desc>minimum memory request per node (currently only used on derecho)</desc>
-   </entry>
- 
-   <entry id="MAX_MEM_PER_NODE">
-     <type>integer</type>
-     <default_value>0</default_value>
-    <group>mach_pes_last</group>
-     <file>env_mach_pes.xml</file>
-     <desc>maximum memory request per node (currently only used on derecho)</desc>
-   </entry>
- 
+
   <entry id="MULTI_DRIVER">
     <type>logical</type>
     <default_value>TRUE</default_value>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -859,7 +859,7 @@
     on linking to the PETSc library. Currently this is used by
     CLM. This is currently only supported for certain machines.</desc>
   </entry>
- 
+
  <entry id="USE_FTORCH">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
@@ -870,7 +870,15 @@
     fortran and a PyTorch model that has been saved to TorchScript.
     </desc>
   </entry>
-  
+
+  <entry id="TORCH_DIR">
+    <type>char</type>
+    <default_value></default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc>location of libtorch and supporting libraries, may be supplied by ftorch interface if not present</desc>
+  </entry>
+
   <entry id="USE_ALBANY">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
@@ -1451,7 +1459,7 @@
     <file>env_run.xml</file>
     <desc>wav2ocn state mapping file</desc>
   </entry>
-  
+
   <entry id="EPS_FRAC">
     <type>char</type>
     <default_value>1.0e-02</default_value>
@@ -1824,7 +1832,7 @@
     <file>env_mach_pes.xml</file>
     <desc>Number of GPUs per node used for simulation </desc>
   </entry>
-  
+
   <entry id="MAX_GPUS_PER_NODE">
     <type>integer</type>
     <default_value>0</default_value>
@@ -1832,7 +1840,7 @@
     <file>env_mach_pes.xml</file>
     <desc>Maximum number of GPUs allowed per node </desc>
   </entry>
-  
+
   <entry id="COSTPES_PER_NODE">
     <type>integer</type>
     <default_value>$MAX_MPITASKS_PER_NODE</default_value>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -379,7 +379,7 @@
     <type>integer</type>
     <default_value>8</default_value>
     <values match="last">
-      <value compset="_DATM.*_MOM6.*_DROF"        >$ATM_NCPL</value>
+      <value compset="_DATM.*_MOM6.*_DROF"        >$OCN_NCPL</value>
       <value compset="_DATM.*_BLOM.*_DROF"        >$ATM_NCPL</value>
       <value compset="_DATM.*_DOCN%SOM"           >$ATM_NCPL</value>
       <value compset="_DATM.*_SLND.*_DICE.*_DOCN" >$ATM_NCPL</value>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -270,6 +270,7 @@
       <value compset=".+" grid="a%ne0np4.ARCTIC.ne30x4"     >192</value>
       <value compset=".+" grid="a%ne0np4.ARCTICGRIS.ne30x8" >384</value>
       <value compset=".+" grid="a%ne0np4.POLARCAP.ne30x4"   >192</value>
+      <value compset=".+" grid="a%ne0np4.NATL.ne30x8"       >384</value>
       <value compset=".+" grid="a%C24"                      >48</value>
       <value compset=".+" grid="a%C48"                      >48</value>
       <value compset=".+" grid="a%C96"                      >48</value>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -289,9 +289,6 @@
       <!-- =================================================== -->
       <value compset="_DATM.*_BLOM">24</value>
       <value compset="_BLOM" grid="oi%tnx0.25v">48</value>
-      <!-- =================================================== -->
-      <!-- EarthWorks specific -->
-      <!-- =================================================== -->
       <value compset=".+" grid="a%mpasa480"                   >48</value>
       <value compset=".+" grid="a%mpasa240"                   >48</value>
       <value compset=".+" grid="a%mpasa120"                   >48</value>
@@ -399,7 +396,8 @@
     <type>integer</type>
     <default_value>8</default_value>
     <values match="last">
-      <value compset="_DATM.*_MPASO.*_DROF"       >$OCN_NCPL</value>
+      <value compset="_DATM.*_MOM6.*_DROF"        >$ATM_NCPL</value>
+      <value compset="_DATM.*_MPASO.*_DROF"        >$ATM_NCPL</value>
       <value compset="_DATM.*_MOM6.*_DROF"        >$OCN_NCPL</value>
       <value compset="_DATM.*_BLOM.*_DROF"        >$ATM_NCPL</value>
       <value compset="_DATM.*_DOCN%SOM"           >$ATM_NCPL</value>
@@ -412,7 +410,6 @@
       <value compset="_DLND.*_CISM\d"             >1</value>
       <value compset="_XROF"                      >$ATM_NCPL</value>
       <value compset="_MPAS"                      >$ATM_NCPL</value>
-      <value compset="_MOSART_" grid="a%mpasa.+"  >$ATM_NCPL</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -440,8 +437,8 @@
     <default_value>FALSE</default_value>
     <values match="last">
       <value compset="DATM.+POP\d">TRUE</value>
-      <value compset="DATM.+MPASO">TRUE</value>
       <value compset="DATM.+MOM\d">TRUE</value>
+      <value compset="DATM.+MPASO">TRUE</value>
       <value compset="DATM.+BLOM\d">TRUE</value>
       <value compset="DATM.+DOCN%IAF">TRUE</value>
       <value compset="DATM%CPLHIST.+POP\d">FALSE</value>

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -119,6 +119,7 @@ contains
     use med_internalstate_mod , only : mapbilnr, mapconsf, mapconsd, mappatch, mappatch_uv3d, mapbilnr_nstod
     use med_internalstate_mod , only : mapfcopy, mapnstod, mapnstod_consd, mapnstod_consf
     use med_internalstate_mod , only : map_rof2ocn_ice, map_rof2ocn_liq
+    use med_internalstate_mod, only : ocn_name, ice_name
     use esmFlds               , only : addfld_ocnalb => med_fldList_addfld_ocnalb
     use esmFlds               , only : addfld_aoflux => med_fldList_addfld_aoflux
     use esmFlds               , only : addmap_aoflux => med_fldList_addmap_aoflux
@@ -1510,15 +1511,17 @@ contains
           call addmrg_to(compatm, 'Si_vice', mrg_from=compice, mrg_fld='Si_vice', mrg_type='copy')
        end if
     end if
-    if (phase == 'advertise') then
-       call addfld_from(compice, 'Si_ithick')
-       call addfld_to(compatm, 'Si_ithick')
-    else
-       if ( fldchk(is_local%wrap%FBexp(compatm)        , 'Si_ithick', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compice,compice), 'Si_ithick', rc=rc)) then
-          call addmap_from(compice, 'Si_ithick', compatm, mapconsf, 'ifrac', ice2atm_map)
-          call addmrg_to(compatm, 'Si_ithick', mrg_from=compice, mrg_fld='Si_ithick', mrg_type='copy')
-       end if
+    if (ice_name == 'mpassi') then
+      if (phase == 'advertise') then
+         call addfld_from(compice, 'Si_ithick')
+         call addfld_to(compatm, 'Si_ithick')
+      else
+         if ( fldchk(is_local%wrap%FBexp(compatm)        , 'Si_ithick', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compice,compice), 'Si_ithick', rc=rc)) then
+            call addmap_from(compice, 'Si_ithick', compatm, mapconsf, 'ifrac', ice2atm_map)
+            call addmrg_to(compatm, 'Si_ithick', mrg_from=compice, mrg_fld='Si_ithick', mrg_type='copy')
+         end if
+      end if
     end if
     if (phase == 'advertise') then
        call addfld_from(compice, 'Si_vsno')
@@ -1798,15 +1801,17 @@ contains
     ! ---------------------------------------------------------------------
     ! to ocn: seaice basal pressure
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compice, 'Si_bpress')
-       call addfld_to(compocn, 'Si_bpress')
-    else
-       if ( fldchk(is_local%wrap%FBImp(compice, compice), 'Si_bpress', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(compocn)         , 'Si_bpress', rc=rc)) then
-          call addmap_from(compice, 'Si_bpress', compocn,  mapfcopy, 'unset', 'unset')
-          call addmrg_to(compocn, 'Si_bpress', mrg_from=compice, mrg_fld='Si_bpress', mrg_type='copy')
-       end if
+    if (ice_name == 'mpassi' .or. ocn_name == 'mpaso') then
+      if (phase == 'advertise') then
+         call addfld_from(compice, 'Si_bpress')
+         call addfld_to(compocn, 'Si_bpress')
+      else
+         if ( fldchk(is_local%wrap%FBImp(compice, compice), 'Si_bpress', rc=rc) .and. &
+              fldchk(is_local%wrap%FBExp(compocn)         , 'Si_bpress', rc=rc)) then
+            call addmap_from(compice, 'Si_bpress', compocn,  mapfcopy, 'unset', 'unset')
+            call addmrg_to(compocn, 'Si_bpress', mrg_from=compice, mrg_fld='Si_bpress', mrg_type='copy')
+         end if
+      end if
     end if
 
     ! ---------------------------------------------------------------------
@@ -2542,228 +2547,228 @@ contains
           call addmrg_to(compocn, 'Sw_lamult', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
        end if
     end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_Hs')
-       call addfld_to(compocn, 'Sw_Hs')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_Hs', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_Hs', rc=rc)) then
-          call addmap_from(compwav, 'Sw_Hs', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_Hs', mrg_from=compwav, mrg_fld='Sw_hs', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_Fp')
-       call addfld_to(compocn, 'Sw_Fp')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_Fp', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_Fp', rc=rc)) then
-          call addmap_from(compwav, 'Sw_Fp', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_Fp', mrg_from=compwav, mrg_fld='Sw_Fp', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_ustokes_wavenumber_1')
-       call addfld_to(compocn, 'Sw_ustokes_wavenumber_1')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_1', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_1', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_1', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_1', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_1', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_vstokes_wavenumber_1')
-       call addfld_to(compocn, 'Sw_vstokes_wavenumber_1')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_1', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_1', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_1', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_1', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_ustokes_wavenumber_2')
-       call addfld_to(compocn, 'Sw_ustokes_wavenumber_2')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_2', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_2', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_2', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_2', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_2', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_vstokes_wavenumber_2')
-       call addfld_to(compocn, 'Sw_vstokes_wavenumber_2')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_2', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_2', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_2', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_2', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_ustokes_wavenumber_3')
-       call addfld_to(compocn, 'Sw_ustokes_wavenumber_3')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_3', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_3', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_3', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_3', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_3', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_vstokes_wavenumber_3')
-       call addfld_to(compocn, 'Sw_vstokes_wavenumber_3')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_3', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_3', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_3', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_3', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_ustokes_wavenumber_4')
-       call addfld_to(compocn, 'Sw_ustokes_wavenumber_4')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_4', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_4', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_4', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_4', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_4', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_vstokes_wavenumber_4')
-       call addfld_to(compocn, 'Sw_vstokes_wavenumber_4')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_4', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_4', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_4', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_4', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_ustokes_wavenumber_5')
-       call addfld_to(compocn, 'Sw_ustokes_wavenumber_5')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_5', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_5', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_5', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_5', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_5', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_vstokes_wavenumber_5')
-       call addfld_to(compocn, 'Sw_vstokes_wavenumber_5')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_5', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_5', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_5', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_5', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_ustokes_wavenumber_6')
-       call addfld_to(compocn, 'Sw_ustokes_wavenumber_6')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_6', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_6', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_6', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_vstokes_wavenumber_6')
-       call addfld_to(compocn, 'Sw_vstokes_wavenumber_6')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_6', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_6', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_ustokes_wavenumber_6')
-       call addfld_to(compocn, 'Sw_ustokes_wavenumber_6')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_6', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_6', rc=rc)) then
-          call addmap_from(compwav, 'Sw_ustokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_ustokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_6', mrg_type='copy')
-       end if
-    end if
-    !-----------------------------
-    ! to ocn: 
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_vstokes_wavenumber_6')
-       call addfld_to(compocn, 'Sw_vstokes_wavenumber_6')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_6', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_6', rc=rc)) then
-          call addmap_from(compwav, 'Sw_vstokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_vstokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
-       end if
-    end if
-
-
-    !-----------------------------
-    ! to ocn:
-    !-----------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compwav, 'Sw_Dp')
-       call addfld_to(compocn, 'Sw_Dp')
-    else
-       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_Dp', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_Dp', rc=rc)) then
-          call addmap_from(compwav, 'Sw_Dp', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
-          call addmrg_to(compocn, 'Sw_Dp', mrg_from=compwav, mrg_fld='Sw_Dp', mrg_type='copy')
-       end if
+    if (ocn_name == 'mpaso') then
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_Hs')
+         call addfld_to(compocn, 'Sw_Hs')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_Hs', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_Hs', rc=rc)) then
+            call addmap_from(compwav, 'Sw_Hs', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_Hs', mrg_from=compwav, mrg_fld='Sw_hs', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_Fp')
+         call addfld_to(compocn, 'Sw_Fp')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_Fp', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_Fp', rc=rc)) then
+            call addmap_from(compwav, 'Sw_Fp', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_Fp', mrg_from=compwav, mrg_fld='Sw_Fp', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_ustokes_wavenumber_1')
+         call addfld_to(compocn, 'Sw_ustokes_wavenumber_1')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_1', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_1', rc=rc)) then
+            call addmap_from(compwav, 'Sw_ustokes_wavenumber_1', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_ustokes_wavenumber_1', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_1', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_vstokes_wavenumber_1')
+         call addfld_to(compocn, 'Sw_vstokes_wavenumber_1')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_1', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_1', rc=rc)) then
+            call addmap_from(compwav, 'Sw_vstokes_wavenumber_1', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_vstokes_wavenumber_1', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_ustokes_wavenumber_2')
+         call addfld_to(compocn, 'Sw_ustokes_wavenumber_2')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_2', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_2', rc=rc)) then
+            call addmap_from(compwav, 'Sw_ustokes_wavenumber_2', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_ustokes_wavenumber_2', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_2', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_vstokes_wavenumber_2')
+         call addfld_to(compocn, 'Sw_vstokes_wavenumber_2')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_2', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_2', rc=rc)) then
+            call addmap_from(compwav, 'Sw_vstokes_wavenumber_2', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_vstokes_wavenumber_2', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_ustokes_wavenumber_3')
+         call addfld_to(compocn, 'Sw_ustokes_wavenumber_3')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_3', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_3', rc=rc)) then
+            call addmap_from(compwav, 'Sw_ustokes_wavenumber_3', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_ustokes_wavenumber_3', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_3', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_vstokes_wavenumber_3')
+         call addfld_to(compocn, 'Sw_vstokes_wavenumber_3')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_3', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_3', rc=rc)) then
+            call addmap_from(compwav, 'Sw_vstokes_wavenumber_3', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_vstokes_wavenumber_3', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_ustokes_wavenumber_4')
+         call addfld_to(compocn, 'Sw_ustokes_wavenumber_4')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_4', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_4', rc=rc)) then
+            call addmap_from(compwav, 'Sw_ustokes_wavenumber_4', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_ustokes_wavenumber_4', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_4', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_vstokes_wavenumber_4')
+         call addfld_to(compocn, 'Sw_vstokes_wavenumber_4')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_4', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_4', rc=rc)) then
+            call addmap_from(compwav, 'Sw_vstokes_wavenumber_4', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_vstokes_wavenumber_4', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_ustokes_wavenumber_5')
+         call addfld_to(compocn, 'Sw_ustokes_wavenumber_5')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_5', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_5', rc=rc)) then
+            call addmap_from(compwav, 'Sw_ustokes_wavenumber_5', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_ustokes_wavenumber_5', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_5', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_vstokes_wavenumber_5')
+         call addfld_to(compocn, 'Sw_vstokes_wavenumber_5')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_5', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_5', rc=rc)) then
+            call addmap_from(compwav, 'Sw_vstokes_wavenumber_5', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_vstokes_wavenumber_5', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_ustokes_wavenumber_6')
+         call addfld_to(compocn, 'Sw_ustokes_wavenumber_6')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_6', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_6', rc=rc)) then
+            call addmap_from(compwav, 'Sw_ustokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_ustokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_6', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_vstokes_wavenumber_6')
+         call addfld_to(compocn, 'Sw_vstokes_wavenumber_6')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_6', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_6', rc=rc)) then
+            call addmap_from(compwav, 'Sw_vstokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_vstokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_ustokes_wavenumber_6')
+         call addfld_to(compocn, 'Sw_ustokes_wavenumber_6')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes_wavenumber_6', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes_wavenumber_6', rc=rc)) then
+            call addmap_from(compwav, 'Sw_ustokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_ustokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_ustokes_wavenumber_6', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn: 
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_vstokes_wavenumber_6')
+         call addfld_to(compocn, 'Sw_vstokes_wavenumber_6')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes_wavenumber_6', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes_wavenumber_6', rc=rc)) then
+            call addmap_from(compwav, 'Sw_vstokes_wavenumber_6', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_vstokes_wavenumber_6', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
+         end if
+      end if
+      !-----------------------------
+      ! to ocn:
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_Dp')
+         call addfld_to(compocn, 'Sw_Dp')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_Dp', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_Dp', rc=rc)) then
+            call addmap_from(compwav, 'Sw_Dp', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_Dp', mrg_from=compwav, mrg_fld='Sw_Dp', mrg_type='copy')
+         end if
+      end if
     end if
     !-----------------------------
     ! to ocn: Stokes drift u component from wave
@@ -3256,15 +3261,17 @@ contains
     ! ---------------------------------------------------------------------
     ! to ice: frazil from ocn
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compocn, 'Fioo_frazil')
-       call addfld_to(compice, 'Fioo_frazil')
-    else
-       if ( fldchk(is_local%wrap%FBImp(compocn, compocn), 'Fioo_frazil', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(compice)         , 'Fioo_frazil', rc=rc)) then
-          call addmap_from(compocn, 'Fioo_frazil', compice,  mapfcopy, 'unset', 'unset')
-          call addmrg_to(compice, 'Fioo_frazil', mrg_from=compocn, mrg_fld='Fioo_frazil', mrg_type='copy')
-       end if
+    if (ocn_name == 'mpaso' .or. ice_name == 'mpassi') then
+      if (phase == 'advertise') then
+         call addfld_from(compocn, 'Fioo_frazil')
+         call addfld_to(compice, 'Fioo_frazil')
+      else
+         if ( fldchk(is_local%wrap%FBImp(compocn, compocn), 'Fioo_frazil', rc=rc) .and. &
+              fldchk(is_local%wrap%FBExp(compice)         , 'Fioo_frazil', rc=rc)) then
+            call addmap_from(compocn, 'Fioo_frazil', compice,  mapfcopy, 'unset', 'unset')
+            call addmrg_to(compice, 'Fioo_frazil', mrg_from=compocn, mrg_fld='Fioo_frazil', mrg_type='copy')
+         end if
+      end if
     end if
     !-----------------------------
     ! to ice: Ratio of ocean surface level abund. H2_16O/H2O/Rstd from ocean

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -1040,6 +1040,8 @@ contains
              call med_map_uv_cart3d(FBsrc, FBdst, routehandles, mapbilnr_uv3d, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
 
+          else if (mapindex == mapconsf_uv3d) then
+
              ! For  mapconsf_uv3d do not use packed field bundles
              call med_map_uv_cart3d(FBsrc, FBdst, routehandles, mapconsf_uv3d, map_stress=.true., rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return


### PR DESCRIPTION
Advance EarthWorksOrg/CMEPS to include changes from the ESCOMP/CMEPS 'cmeps1.1.2' tag. This matches with updates of other externals to what's used in ESCOMP/CESM tag 'cesm3_0_alpha07b'.
